### PR TITLE
June 2025 Android update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ These keywords depend on the language of your browser. Google Calendar recognize
 
 See [en_us/keywords.md](en_us/keywords.md) for the US English list.
 
+## June 2025 Android update
+
+Reports from devices running Google Calendar version 2024.37.0-674942318-release
+indicate that Google is rolling out a refreshed flair design that removes several
+previously supported keywords. Keywords such as `archery`, `ballet`,
+`back 2 school`, `billiard`, `boxing`, `car maintenance`, `codecademy`, `coding
+time`, `computer science`, `dressage`, `fencing`, `hackathon`, `hour of code`,
+`javelin`, `manicure`, `programming in java`, `programming in python`, `rails
+girls`, `railsgirls`, `shooting sport`, `shooting sports`, `theatre`, `web
+development`, and `web programming` no longer trigger flairs on Android, so
+they have been removed from the US English list. The keyword `back2school`
+continues to work with the new design.
+
 Here are other useful links:
 
 * [How to add pictures to your Google (with images)](https://momof3plus2.blogspot.com/2017/10/how-to-add-pictures-to-your-google.html)

--- a/en_us/keywords.md
+++ b/en_us/keywords.md
@@ -16,8 +16,6 @@ allhalloween
 
 american football
 
-archery
-
 art workshop
 
 art workshops
@@ -36,8 +34,6 @@ babyshower
 
 bachelorette party
 
-back 2 school
-
 back rub
 
 back to school
@@ -49,8 +45,6 @@ backrub
 backtoschool
 
 badminton
-
-ballet
 
 barbecue
 
@@ -76,8 +70,6 @@ bikes
 
 biking
 
-billiard
-
 birthday
 
 bmx
@@ -98,8 +90,6 @@ bouldering
 
 bowling
 
-boxing
-
 Boxing Day
 
 breakfast
@@ -119,8 +109,6 @@ candlelight dinner
 canoe
 
 canoeing
-
-car maintenance
 
 car mechanic
 
@@ -184,17 +172,11 @@ cocktail
 
 cocktails
 
-codecademy
-
-coding time
-
 coffee
 
 coffees
 
 competitive shooting
-
-computer science
 
 concert
 
@@ -260,8 +242,6 @@ dogsitting
 
 drawing workshop
 
-dressage
-
 drinks
 
 dyke march
@@ -291,8 +271,6 @@ Fat Tuesday
 father christmas
 
 felting
-
-fencing
 
 field hockey
 
@@ -354,8 +332,6 @@ guitar lesson
 
 gym
 
-hackathon
-
 hair
 
 haircut
@@ -396,11 +372,7 @@ horse riding
 
 horseriding
 
-hour of code
-
 Islamic New Year
-
-javelin
 
 jiu jitsu
 
@@ -443,10 +415,6 @@ lunches
 make dinner
 
 make lunch
-
-manicure
-
-manicures
 
 mardi gras
 
@@ -552,17 +520,9 @@ prepare lunch
 
 prepare meal
 
-programming in java
-
-programming in python
-
 quilting
 
 quinceanera
-
-rails girls
-
-railsgirls
 
 reach out to
 
@@ -603,10 +563,6 @@ sewing
 SGDQ
 
 shooting competition
-
-shooting sport
-
-shooting sports
 
 shot put
 
@@ -678,8 +634,6 @@ thanksgiving
 
 theater
 
-theatre
-
 tidy up
 
 tire change
@@ -735,10 +689,6 @@ walking
 water polo
 
 waterpolo
-
-web development
-
-web programming
 
 wedding
 


### PR DESCRIPTION

## June 2025 Android update
--
 
Reports from devices running Google Calendar version 2024.37.0-674942318-release
indicate that Google is rolling out a refreshed flair design that removes several
previously supported keywords. Keywords such as `archery`, `ballet`,
`back 2 school`, `billiard`, `boxing`, `car maintenance`, `codecademy`, `coding
time`, `computer science`, `dressage`, `fencing`, `hackathon`, `hour of code`,
`javelin`, `manicure`, `programming in java`, `programming in python`, `rails
girls`, `railsgirls`, `shooting sport`, `shooting sports`, `theatre`, `web
development`, and `web programming` no longer trigger flairs on Android, so
they have been removed from the US English list. The keyword `back2school`
continues to work with the new design.

