### PR TITLE
Add new travel-related keywords

### DIFF
--- a/en_us/keywords.md
+++ b/en_us/keywords.md
@@ -290,6 +290,8 @@ fitness test
 
 fitness training
 
+flight
+
 flute
 
 football
@@ -641,6 +643,10 @@ tire change
 tire replacement
 
 track and field
+
+travel
+
+trip
 
 triathlon
 


### PR DESCRIPTION
## Summary
- add "flight" to the English keyword list for Google Calendar flairs
- add "travel" and "trip" to the English keyword list so they appear in the refreshed design

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d51ec1f1788322b5ab762b7f6cabfe