### PR TITLE
Create pt_br/keywords.md

### DIFF
--- a/pt_br/keywords.md
+++ b/pt_br/keywords.md
@@ -1,0 +1,21 @@
+See [Top-level README.md](../README.md) for description of what this list means.
+
+Academia
+
+Almoço
+
+Aikido
+
+Arrumar
+
+Aula de música
+
+Café
+
+Cozinhar
+
+Dentista
+
+Estudo
+
+Jantar


### PR DESCRIPTION
This PR adds initial Portuguese (Brazil) keywords that trigger Google Calendar illustrations in agenda view.

The keywords included are commonly used calendar event titles in Brazilian Portuguese, such as:

Academia (gym/fitness)
Almoço (lunch)
Arrumar (organizing/cleaning)
Dentista (dentist)
Estudo (study)
And others
This creates the pt_br folder following the same structure as other language folders in the repository. More keywords can be added by the community over time.